### PR TITLE
feat: add show-preview button

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "commands": [
       {
         "command": "abcjs-vscode.showPreview",
-        "title": "abcjs-vscode: Show Preview"
+        "title": "abcjs-vscode: Show Preview",
+        "icon": "$(open-preview)"
       },
       {
         "command": "abcjs-vscode.exportHtml",
@@ -39,6 +40,15 @@
         "title": "abcjs-vscode: Print Preview"
       }
     ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "abcjs-vscode.showPreview",
+          "group": "navigation",
+          "when": "resourceLangId == abc"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "abc",


### PR DESCRIPTION
I really like this extension and plan to add some features.

This feature adds a preview button to the navigation bar of the `.abc` file, making it more convenient to use.