### PR TITLE
feat: double click can focus on text for editing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,10 @@ let outputChannel: vscode.OutputChannel;
 let svgHandler: Function; // the function that receives the SVG
 let _context: vscode.ExtensionContext;
 
+// Track the last click for double-click detection
+let lastClickedStart: number = -1;
+let lastClickedEnd: number = -1;
+
 /**
  * @param {vscode.ExtensionContext} context
  */
@@ -136,8 +140,8 @@ function initializePanel(context: vscode.ExtensionContext) {
   panel.webview.onDidReceiveMessage((message) => {
     switch (message.name) {
       case 'click':
-        // Select the character in the editor.
-        select(message.startChar, message.endChar);
+        // Handle single click or double click on the same note
+        handleClick(message.startChar, message.endChar);
         break;
 
       case 'svgExport':
@@ -378,6 +382,38 @@ function select(start: number, end: number) {
 
   editor.selection = new vscode.Selection(startPos, endPos);
   editor.revealRange(editor.selection);
+}
+
+/**
+ * Handle note click - single click selects text, double click on same note focuses for editing.
+ * @param {Number} start
+ * @param {Number} end
+ */
+function handleClick(start: number, end: number) {
+  // Check double-click
+  if (start === lastClickedStart && end === lastClickedEnd) {
+    focus(start);
+  } else {
+    select(start, end);
+  }
+
+  // Update the last clicked position
+  lastClickedStart = start;
+  lastClickedEnd = end;
+}
+
+/**
+ * Focus on the start of selected text for editing.
+ * @param {Number} start
+ */
+function focus(start: number) {
+  const editor = getEditor();
+
+  const startPos = editor.document.positionAt(start);
+
+  editor.selection  = new vscode.Selection(startPos, startPos);
+  editor.revealRange(editor.selection);
+  vscode.window.showTextDocument(editor.document, editor.viewColumn);
 }
 
 function getNormalizedEditorContent(editor?: vscode.TextEditor) {


### PR DESCRIPTION
When the same note is clicked twice, the cursor will appear to the left of the text, allowing for direct editing.